### PR TITLE
Make Key enum non_exhaustive to future proof + Put os_keyring behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "Apache-2.0"
 
 [features]
 mocks = ["mockall"]
+os_keyring = ["keyring"]
 
 [dependencies]
 cosmrs = { version = "0.10.0", features = ["rpc", "cosmwasm", "grpc"] }
@@ -24,7 +25,8 @@ thiserror = "1.0.31"
 regex = "1.6.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
-keyring = "1.2.0"
+
+keyring = { version = "1.2.0", optional = true }
 mockall = { version = "0.11.2", optional = true }
 
 [dev-dependencies]

--- a/src/chain/error.rs
+++ b/src/chain/error.rs
@@ -2,9 +2,11 @@ use cosmrs::proto::prost::{DecodeError, EncodeError};
 use cosmrs::ErrorReport;
 use thiserror::Error;
 
+#[cfg(feature = "os_keyring")]
+pub use keyring::Error as KeyringError;
+
 pub use cosmrs::rpc::Error as TendermintRPCError;
 pub use cosmrs::tendermint::Error as TendermintError;
-pub use keyring::Error as KeyringError;
 pub use tonic::transport::Error as CosmosGRPCError;
 
 use super::response::ChainResponse;
@@ -41,6 +43,7 @@ pub enum ChainError {
     #[error("invalid cosmos msg sent to simulate endpoint")]
     Simulation,
 
+    #[cfg(feature = "os_keyring")]
     #[error(transparent)]
     Keyring(#[from] KeyringError),
 

--- a/src/modules/bank/model.rs
+++ b/src/modules/bank/model.rs
@@ -212,7 +212,7 @@ impl fmt::Display for SendRequest {
         write!(f, "{} sends ", self.from)?;
 
         for a in &self.amounts {
-            write!(f, "{} ", a)?;
+            write!(f, "{a} ")?;
         }
 
         write!(f, "-> {}", self.to)

--- a/src/signing_key/key.rs
+++ b/src/signing_key/key.rs
@@ -1,6 +1,8 @@
 use cosmrs::bip32;
 use cosmrs::bip32::secp256k1::elliptic_curve::rand_core::OsRng;
 use cosmrs::crypto::secp256k1;
+
+#[cfg(feature = "os_keyring")]
 use keyring::Entry;
 
 use crate::chain::error::ChainError;
@@ -38,6 +40,7 @@ impl SigningKey {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Key {
     /// Mnemonic allows you to pass the private key mnemonic words
     /// to Cosm-orc for configuring a transaction signing key.
@@ -47,8 +50,9 @@ pub enum Key {
     // TODO: Add Keyring password CRUD operations
     /// Use OS Keyring to access private key.
     /// Safe for testnet / mainnet.
+    #[cfg(feature = "os_keyring")]
     Keyring(KeyringParams),
-    // TODO: Add ledger support
+    // TODO: Add ledger support(under a new ledger feature flag / Key variant)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,16 +63,18 @@ pub struct KeyringParams {
 
 impl TryFrom<SigningKey> for secp256k1::SigningKey {
     type Error = ChainError;
-    fn try_from(signer: SigningKey) -> Result<secp256k1::SigningKey, Self::Error> {
+    fn try_from(signer: SigningKey) -> Result<Self, Self::Error> {
         secp256k1::SigningKey::try_from(&signer)
     }
 }
 
 impl TryFrom<&SigningKey> for secp256k1::SigningKey {
     type Error = ChainError;
-    fn try_from(signer: &SigningKey) -> Result<secp256k1::SigningKey, Self::Error> {
+    fn try_from(signer: &SigningKey) -> Result<Self, Self::Error> {
         match &signer.key {
             Key::Mnemonic(phrase) => mnemonic_to_signing_key(phrase),
+
+            #[cfg(feature = "os_keyring")]
             Key::Keyring(params) => {
                 let entry = Entry::new(&params.service, &params.key_name);
                 mnemonic_to_signing_key(&entry.get_password()?)


### PR DESCRIPTION
`cosm-orc` doesnt need to use the `keyring` lib so we should put it behind a feature flag, to cut down on compilation time.

Also, `Key` enum is going to have more variants added in the future, so I made it non_exhaustive.