### PR TITLE
rename gas_prices to gas_price

### DIFF
--- a/src/config/cfg.rs
+++ b/src/config/cfg.rs
@@ -9,6 +9,6 @@ pub struct ChainConfig {
     pub chain_id: String,
     pub rpc_endpoint: Option<String>,
     pub grpc_endpoint: Option<String>,
-    pub gas_prices: f64,
+    pub gas_price: f64,
     pub gas_adjustment: f64,
 }

--- a/src/modules/bank/api.rs
+++ b/src/modules/bank/api.rs
@@ -272,7 +272,7 @@ mod tests {
             chain_id: "test-1".to_string(),
             rpc_endpoint: Some("localhost".to_string()),
             grpc_endpoint: None,
-            gas_prices: 0.1,
+            gas_price: 0.1,
             gas_adjustment: 1.5,
         };
 
@@ -340,7 +340,7 @@ mod tests {
             chain_id: "test-1".to_string(),
             rpc_endpoint: None,
             grpc_endpoint: None,
-            gas_prices: 0.1,
+            gas_price: 0.1,
             gas_adjustment: 1.5,
         };
         let tx_options = TxOptions::default();
@@ -439,7 +439,7 @@ mod tests {
             chain_id: "test-1".to_string(),
             rpc_endpoint: None,
             grpc_endpoint: None,
-            gas_prices: 0.1,
+            gas_price: 0.1,
             gas_adjustment: 1.5,
         };
 

--- a/src/modules/tx/api.rs
+++ b/src/modules/tx/api.rs
@@ -103,7 +103,7 @@ impl<T: CosmosClient> CosmTome<T> {
         let gas_limit = (gas_info.gas_used.value() as f64 * self.cfg.gas_adjustment).ceil();
         let amount = Coin {
             denom,
-            amount: ((gas_limit * self.cfg.gas_prices).ceil() as u64).into(),
+            amount: ((gas_limit * self.cfg.gas_price).ceil() as u64).into(),
         };
 
         let fee = Fee::new(amount, gas_limit as u64, None, None);


### PR DESCRIPTION
I think the generally accepted term here is gas_price, not prices.