### PR TITLE
Add support for sequence adjustments on tx sign for accounts

### DIFF
--- a/src/chain/request.rs
+++ b/src/chain/request.rs
@@ -99,6 +99,11 @@ pub struct TxOptions {
 
     /// An arbitrary memo to be added to the transaction
     pub memo: String,
+
+    /// Adjust account sequence for cases:
+    /// - Chain errors with "account sequence mismatch, expected 2, got 1"
+    /// - multiple batched signed txns, such that you want inclusion within same block
+    pub sequence: Option<u64>,
 }
 
 impl Default for TxOptions {
@@ -107,6 +112,7 @@ impl Default for TxOptions {
             fee: None,
             timeout_height: Some(0),
             memo: "Made with cosm-tome client".to_string(),
+            sequence: None,
         }
     }
 }

--- a/src/modules/tx/api.rs
+++ b/src/modules/tx/api.rs
@@ -37,7 +37,11 @@ impl<T: CosmosClient> CosmTome<T> {
         };
 
         let timeout_height = tx_options.timeout_height.unwrap_or_default();
-        let account = self.auth_query_account(sender_addr).await?.account;
+        let mut account = self.auth_query_account(sender_addr).await?.account;
+
+        if let Some(sequence) = &tx_options.sequence {
+            account.sequence = *sequence;
+        }
 
         // even if the user is supplying their own `Fee`, we will simulate the tx to ensure its valid
         let sim_fee = self


### PR DESCRIPTION
There seems to be a problem for bank_send that occurs:

```
ChainResponse { code: Err(6), data: Some([]), log: "rpc error: code = Unknown desc = account sequence mismatch, expected 840, got 470: incorrect account sequence [cosmos/cosmos-sdk@v0.45.15/x/auth/ante/sigverify.go:265] With gas wanted: '100000000' and gas used: '39246' : unknown request" }
```

So the idea here is to give flexibilty to cache errors like this, to hopefully enable to retry with valid sequence.

If theres a better way to handle this, im all 👂 