### PR TITLE
sweeping changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosm-tome"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["Harry Hull <harry.hull1@gmail.com>"]
 
@@ -17,8 +17,9 @@ mocks = ["mockall"]
 os_keyring = ["keyring"]
 
 [dependencies]
-cosmrs = { version = "0.10.0", features = ["rpc", "cosmwasm", "grpc"] }
-tonic = { version = "0.8.2", default-features=false, features = ["transport", "prost"] }
+cosmrs = { version = "0.14.0", features = ["rpc", "cosmwasm", "grpc"] }
+tendermint-rpc = "0.32.0"
+tonic = { version = "0.9.2", default-features=false, features = ["transport", "prost"] }
 
 async-trait = "0.1.57"
 thiserror = "1.0.31"
@@ -27,7 +28,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 schemars = "0.8"
 
-keyring = { version = "1.2.0", optional = true }
+keyring = { version = "2", optional = true }
 mockall = { version = "0.11.2", optional = true }
 
 [dev-dependencies]

--- a/src/chain/error.rs
+++ b/src/chain/error.rs
@@ -9,7 +9,7 @@ pub use cosmrs::rpc::Error as TendermintRPCError;
 pub use cosmrs::tendermint::Error as TendermintError;
 pub use tonic::transport::Error as CosmosGRPCError;
 
-use super::response::ChainResponse;
+// use super::response::ChainResponse;
 
 #[derive(Error, Debug)]
 pub enum ChainError {
@@ -47,8 +47,25 @@ pub enum ChainError {
     #[error(transparent)]
     Keyring(#[from] KeyringError),
 
-    #[error("CosmosSDK error: {res:?}")]
-    CosmosSdk { res: ChainResponse },
+    #[error("Tonic error {0}")]
+    Tonic(#[from] tonic::Status),
+
+    // #[error("CosmosSDK error: {res:?}")]
+    // CosmosSdk { res: ChainResponse },
+    #[error("TxSync error: {res:?}")]
+    TxCommit {
+        res: tendermint_rpc::endpoint::broadcast::tx_commit::Response,
+    },
+
+    #[error("TxSync error: {res:?}")]
+    TxSync {
+        res: tendermint_rpc::endpoint::broadcast::tx_sync::Response,
+    },
+
+    #[error("TxAsync error: {res:?}")]
+    TxAsync {
+        res: tendermint_rpc::endpoint::broadcast::tx_async::Response,
+    },
 
     #[error("Tendermint error")]
     Tendermint(#[from] TendermintError),
@@ -87,9 +104,9 @@ impl ChainError {
         }
     }
 
-    pub(crate) fn tonic_status(e: tonic::Status) -> ChainError {
-        ChainError::CosmosSdk { res: e.into() }
-    }
+    // pub(crate) fn tonic_status(e: tonic::Status) -> ChainError {
+    //     e.into()
+    // }
 }
 
 #[derive(Error, Debug)]

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -1,6 +1,6 @@
 pub mod request;
 
-pub mod response;
+// pub mod response;
 
 pub mod coin;
 

--- a/src/chain/request.rs
+++ b/src/chain/request.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use cosmrs::proto::cosmos::base::query::v1beta1::{PageRequest, PageResponse};
 
+use crate::modules::auth::model::Account;
+
 use super::fee::Fee;
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Hash)]
@@ -94,25 +96,23 @@ pub struct TxOptions {
     /// The block height after which this transaction will not be processed by the chain
     pub timeout_height: Option<u64>,
 
-    /// If set will use this fee, instead of the simulated gas price
+    /// If set, this fee will be used, instead of simulating the fee
     pub fee: Option<Fee>,
+
+    /// If set, this fee will be used, instead of querying the account
+    pub account: Option<Account>,
 
     /// An arbitrary memo to be added to the transaction
     pub memo: String,
-
-    /// Adjust account sequence for cases:
-    /// - Chain errors with "account sequence mismatch, expected 2, got 1"
-    /// - multiple batched signed txns, such that you want inclusion within same block
-    pub sequence: Option<u64>,
 }
 
 impl Default for TxOptions {
     fn default() -> Self {
         Self {
             fee: None,
+            account: None,
             timeout_height: Some(0),
             memo: "Made with cosm-tome client".to_string(),
-            sequence: None,
         }
     }
 }

--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -1,23 +1,15 @@
+use crate::chain::fee::GasInfo;
+use crate::{chain::error::ChainError, modules::tx::model::RawTx};
 use async_trait::async_trait;
 use cosmrs::proto::traits::Message;
 
-use crate::chain::error::ChainError;
-use crate::chain::fee::GasInfo;
-use crate::chain::response::{AsyncChainTxResponse, ChainTxResponse};
-use crate::config::cfg::ChainConfig;
-use crate::modules::tx::model::{BroadcastMode, RawTx};
-
-use super::cosmos_grpc::CosmosgRPC;
-use super::tendermint_rpc::TendermintRPC;
-
 #[cfg(feature = "mocks")]
 use mockall::automock;
+use tendermint_rpc::endpoint::broadcast::{tx_async, tx_commit, tx_sync};
 
 #[cfg_attr(feature = "mocks", automock)]
 #[async_trait]
-pub trait CosmosClient {
-    // NOTE: We can make `query()` dynamically dispatched and trait object usable
-    // if prost fixes this: https://github.com/tokio-rs/prost/issues/742
+pub trait CosmosClientQuery {
     async fn query<I, O>(&self, msg: I, path: &str) -> Result<O, ChainError>
     where
         Self: Sized,
@@ -25,67 +17,31 @@ pub trait CosmosClient {
         O: Message + Default + 'static;
 
     async fn simulate_tx(&self, tx: &RawTx) -> Result<GasInfo, ChainError>;
-
-    async fn broadcast_tx(
-        &self,
-        tx: &RawTx,
-        mode: BroadcastMode,
-    ) -> Result<AsyncChainTxResponse, ChainError>;
-
-    /// TODO: Block BroadcastMode support is being dropped from future Cosmos-Sdk versions.
-    /// Cosm-tome will continue to support it by broadcasting with the Sync mode
-    /// and then polling the GetTransaction endpoint until it has been committed in the block.
-    async fn broadcast_tx_block(&self, tx: &RawTx) -> Result<ChainTxResponse, ChainError>;
 }
 
-#[derive(Clone, Debug)]
-pub struct CosmTome<T: CosmosClient> {
-    pub(crate) cfg: ChainConfig,
-    pub client: T,
+#[cfg_attr(feature = "mocks", automock)]
+#[async_trait]
+pub trait CosmosClientCommit {
+    async fn broadcast_tx_commit(&self, tx: &RawTx) -> Result<tx_commit::Response, ChainError>;
 }
 
-impl<T: CosmosClient> CosmTome<T> {
-    /// General usage CosmClient constructor accepting any client that impls `CosmosClient` trait
-    pub fn new(cfg: ChainConfig, client: T) -> Self {
-        Self { cfg, client }
-    }
+#[cfg_attr(feature = "mocks", automock)]
+#[async_trait]
+pub trait CosmosClientSync {
+    async fn broadcast_tx_sync(&self, tx: &RawTx) -> Result<tx_sync::Response, ChainError>;
 }
 
-impl CosmTome<TendermintRPC> {
-    pub fn with_tendermint_rpc(cfg: ChainConfig) -> Result<CosmTome<TendermintRPC>, ChainError> {
-        let rpc_endpoint = cfg
-            .rpc_endpoint
-            .clone()
-            .ok_or(ChainError::MissingApiEndpoint {
-                api_type: "tendermint_rpc".to_string(),
-            })?;
-
-        Ok(CosmTome {
-            client: TendermintRPC::new(&rpc_endpoint)?,
-            cfg,
-        })
-    }
+#[cfg_attr(feature = "mocks", automock)]
+#[async_trait]
+pub trait CosmosClientAsync {
+    async fn broadcast_tx_async(&self, tx: &RawTx) -> Result<tx_async::Response, ChainError>;
 }
 
-impl CosmTome<CosmosgRPC> {
-    pub fn with_cosmos_grpc(cfg: ChainConfig) -> Result<CosmTome<CosmosgRPC>, ChainError> {
-        let grpc_endpoint = cfg
-            .grpc_endpoint
-            .clone()
-            .ok_or(ChainError::MissingApiEndpoint {
-                api_type: "cosmos_grpc".to_string(),
-            })?;
+// #[cfg(test)]
+// mod tests {
+//     use super::CosmosClient;
 
-        Ok(CosmTome {
-            client: CosmosgRPC::new(grpc_endpoint),
-            cfg,
-        })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::CosmosClient;
-
-    const _MESSAGE_IS_OBJECT_SAFE: Option<&dyn CosmosClient> = None;
-}
+//     const _MESSAGE_IS_OBJECT_SAFE: Option<
+//         &dyn CosmosClient<TxResponse = (), AsyncTxResponse = ()>,
+//     > = None;
+// }

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -1,4 +1,4 @@
 pub mod client;
 
-pub mod cosmos_grpc;
+// pub mod cosmos_grpc;
 pub mod tendermint_rpc;

--- a/src/clients/tendermint_rpc.rs
+++ b/src/clients/tendermint_rpc.rs
@@ -2,13 +2,13 @@ use async_trait::async_trait;
 use cosmrs::proto::cosmos::tx::v1beta1::{SimulateRequest, SimulateResponse};
 use cosmrs::proto::traits::Message;
 use cosmrs::rpc::{Client, HttpClient};
+use tendermint_rpc::endpoint::broadcast::{tx_async, tx_commit, tx_sync};
 
 use crate::chain::error::ChainError;
 use crate::chain::fee::GasInfo;
-use crate::chain::response::{AsyncChainTxResponse, ChainTxResponse};
-use crate::modules::tx::model::{BroadcastMode, RawTx};
+use crate::modules::tx::model::RawTx;
 
-use super::client::CosmosClient;
+use super::client::{CosmosClientAsync, CosmosClientCommit, CosmosClientQuery, CosmosClientSync};
 
 #[derive(Clone, Debug)]
 pub struct TendermintRPC {
@@ -31,7 +31,7 @@ impl TendermintRPC {
 }
 
 #[async_trait]
-impl CosmosClient for TendermintRPC {
+impl CosmosClientQuery for TendermintRPC {
     async fn query<I, O>(&self, msg: I, path: &str) -> Result<O, ChainError>
     where
         I: Message + Default + tonic::IntoRequest<I> + 'static,
@@ -41,12 +41,8 @@ impl CosmosClient for TendermintRPC {
 
         let res = self
             .client
-            .abci_query(Some(path.parse()?), bytes, None, false)
+            .abci_query(Some(path.to_string()), bytes, None, false)
             .await?;
-
-        if res.code.is_err() {
-            return Err(ChainError::CosmosSdk { res: res.into() });
-        }
 
         let proto_res =
             O::decode(res.value.as_slice()).map_err(ChainError::prost_proto_decoding)?;
@@ -66,16 +62,12 @@ impl CosmosClient for TendermintRPC {
         let res = self
             .client
             .abci_query(
-                Some("/cosmos.tx.v1beta1.Service/Simulate".parse()?),
+                Some("/cosmos.tx.v1beta1.Service/Simulate".to_string()),
                 bytes,
                 None,
                 false,
             )
             .await?;
-
-        if res.code.is_err() {
-            return Err(ChainError::CosmosSdk { res: res.into() });
-        }
 
         let gas_info = SimulateResponse::decode(res.value.as_slice())
             .map_err(ChainError::prost_proto_decoding)?
@@ -84,49 +76,43 @@ impl CosmosClient for TendermintRPC {
 
         Ok(gas_info.into())
     }
+}
 
-    async fn broadcast_tx(
-        &self,
-        tx: &RawTx,
-        mode: BroadcastMode,
-    ) -> Result<AsyncChainTxResponse, ChainError> {
-        let res: AsyncChainTxResponse = match mode {
-            BroadcastMode::Sync => self
-                .client
-                .broadcast_tx_sync(tx.to_bytes()?.into())
-                .await?
-                .into(),
-            BroadcastMode::Async => self
-                .client
-                .broadcast_tx_async(tx.to_bytes()?.into())
-                .await?
-                .into(),
-        };
+#[async_trait]
+impl CosmosClientCommit for TendermintRPC {
+    async fn broadcast_tx_commit(&self, tx: &RawTx) -> Result<tx_commit::Response, ChainError> {
+        let res = self.client.broadcast_tx_commit(tx.to_bytes()?).await?;
 
-        if res.res.code.is_err() {
-            return Err(ChainError::CosmosSdk { res: res.res });
+        if res.check_tx.code.is_err() || res.deliver_tx.code.is_err() {
+            return Err(ChainError::TxCommit { res });
         }
 
         Ok(res)
     }
+}
 
-    async fn broadcast_tx_block(&self, tx: &RawTx) -> Result<ChainTxResponse, ChainError> {
-        let res = self
-            .client
-            .broadcast_tx_commit(tx.to_bytes()?.into())
-            .await?;
+#[async_trait]
+impl CosmosClientSync for TendermintRPC {
+    async fn broadcast_tx_sync(&self, tx: &RawTx) -> Result<tx_sync::Response, ChainError> {
+        let res = self.client.broadcast_tx_sync(tx.to_bytes()?).await?;
 
-        if res.check_tx.code.is_err() {
-            return Err(ChainError::CosmosSdk {
-                res: res.check_tx.into(),
-            });
-        }
-        if res.deliver_tx.code.is_err() {
-            return Err(ChainError::CosmosSdk {
-                res: res.deliver_tx.into(),
-            });
+        if res.code.is_err() {
+            return Err(ChainError::TxSync { res });
         }
 
-        Ok(res.into())
+        Ok(res)
+    }
+}
+
+#[async_trait]
+impl CosmosClientAsync for TendermintRPC {
+    async fn broadcast_tx_async(&self, tx: &RawTx) -> Result<tx_async::Response, ChainError> {
+        let res = self.client.broadcast_tx_async(tx.to_bytes()?).await?;
+
+        if res.code.is_err() {
+            return Err(ChainError::TxAsync { res });
+        }
+
+        Ok(res)
     }
 }

--- a/src/config/cfg.rs
+++ b/src/config/cfg.rs
@@ -13,10 +13,6 @@ pub struct ChainConfig {
     pub chain_id: String,
     /// example: "m/44'/118'/0'/0/0"
     pub derivation_path: String,
-    /// example: "https://terra-testnet-rpc.polkachu.com"
-    pub rpc_endpoint: Option<String>,
-    /// example: "https://terra-testnet-grpc.polkachu.com:11790"
-    pub grpc_endpoint: Option<String>,
     /// example: 0.025
     pub gas_price: f64,
     /// example: 1.3

--- a/src/modules/bank/model.rs
+++ b/src/modules/bank/model.rs
@@ -10,9 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::chain::coin::Denom;
 use crate::chain::msg::Msg;
 use crate::{
-    chain::{
-        coin::Coin, error::ChainError, request::PaginationResponse, response::ChainTxResponse,
-    },
+    chain::{coin::Coin, error::ChainError, request::PaginationResponse},
     modules::auth::model::Address,
 };
 
@@ -64,6 +62,8 @@ pub struct DenomMetadata {
     ///
     /// Since: cosmos-sdk 0.43
     pub symbol: String,
+    pub uri: String,
+    pub uri_hash: String,
 }
 
 impl TryFrom<Metadata> for DenomMetadata {
@@ -81,6 +81,8 @@ impl TryFrom<Metadata> for DenomMetadata {
             display: meta.display,
             name: meta.name,
             symbol: meta.symbol,
+            uri: meta.uri,
+            uri_hash: meta.uri_hash,
         })
     }
 }
@@ -94,6 +96,8 @@ impl From<DenomMetadata> for Metadata {
             display: meta.display,
             name: meta.name,
             symbol: meta.symbol,
+            uri: meta.uri,
+            uri_hash: meta.uri_hash,
         }
     }
 }
@@ -260,7 +264,7 @@ impl TryFrom<SendRequest> for MsgSend {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq)]
-pub struct SendResponse {
-    pub res: ChainTxResponse,
-}
+// #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq)]
+// pub struct SendResponse {
+//     pub res: ChainTxResponse,
+// }

--- a/src/modules/cosmwasm/api.rs
+++ b/src/modules/cosmwasm/api.rs
@@ -1,13 +1,14 @@
+use async_trait::async_trait;
 use serde::Serialize;
 
 use crate::chain::request::TxOptions;
-use crate::clients::client::CosmTome;
+use crate::clients::client::CosmosClientQuery;
 use cosmrs::proto::cosmwasm::wasm::v1::{
     QuerySmartContractStateRequest, QuerySmartContractStateResponse,
 };
 
 use crate::modules::auth::model::Address;
-use crate::{clients::client::CosmosClient, signing_key::key::SigningKey};
+use crate::signing_key::key::SigningKey;
 
 use super::model::{
     ExecRequest, ExecResponse, InstantiateBatchResponse, InstantiateRequest, MigrateRequest,
@@ -18,8 +19,11 @@ use super::{
     model::{InstantiateResponse, StoreCodeResponse},
 };
 
-impl<T: CosmosClient> CosmTome<T> {
-    pub async fn wasm_store(
+impl<T> CosmwasmQuery for T where T: CosmosClientQuery {}
+
+#[async_trait]
+pub trait CosmwasmQuery: CosmosClientQuery + Sized {
+    async fn wasm_store(
         &self,
         req: StoreCodeRequest,
         key: &SigningKey,
@@ -33,7 +37,7 @@ impl<T: CosmosClient> CosmTome<T> {
         })
     }
 
-    pub async fn wasm_store_batch<I>(
+    async fn wasm_store_batch<I>(
         &self,
         reqs: I,
         key: &SigningKey,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -2,8 +2,8 @@ pub mod auth;
 
 pub mod bank;
 
-pub mod cosmwasm;
+// pub mod cosmwasm;
 
 pub mod tx;
 
-pub mod tendermint;
+// pub mod tendermint;

--- a/src/modules/tendermint/api.rs
+++ b/src/modules/tendermint/api.rs
@@ -1,20 +1,21 @@
+use async_trait::async_trait;
 use cosmrs::proto::cosmos::base::tendermint::v1beta1::{
     GetLatestBlockRequest, GetLatestBlockResponse, GetLatestValidatorSetRequest,
     GetLatestValidatorSetResponse, GetValidatorSetByHeightRequest, GetValidatorSetByHeightResponse,
 };
 
-use crate::{
-    chain::request::PaginationRequest,
-    clients::client::{CosmTome, CosmosClient},
-};
+use crate::{chain::request::PaginationRequest, clients::client::CosmosClientQuery};
 
 use super::{
     error::TendermintError,
     model::{BlockResponse, ValidatorSetResponse},
 };
 
-impl<T: CosmosClient> CosmTome<T> {
-    pub async fn tendermint_query_latest_block(&self) -> Result<BlockResponse, TendermintError> {
+impl<T> TendermintQuery for T where T: CosmosClientQuery {}
+
+#[async_trait]
+pub trait TendermintQuery: CosmosClientQuery + Sized {
+    async fn tendermint_query_latest_block(&self) -> Result<BlockResponse, TendermintError> {
         let req = GetLatestBlockRequest {};
 
         let res = self
@@ -28,7 +29,7 @@ impl<T: CosmosClient> CosmTome<T> {
         res.try_into()
     }
 
-    pub async fn tendermint_query_latest_validator_set(
+    async fn tendermint_query_latest_validator_set(
         &self,
         pagination: Option<PaginationRequest>,
     ) -> Result<ValidatorSetResponse, TendermintError> {
@@ -47,7 +48,7 @@ impl<T: CosmosClient> CosmTome<T> {
         res.try_into()
     }
 
-    pub async fn tendermint_query_validator_set_at_height(
+    async fn tendermint_query_validator_set_at_height(
         &self,
         block_height: u64,
         pagination: Option<PaginationRequest>,

--- a/src/modules/tx/model.rs
+++ b/src/modules/tx/model.rs
@@ -19,6 +19,7 @@ use super::error::TxError;
 )]
 #[repr(i32)]
 pub enum BroadcastMode {
+    Block = 1,
     /// BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits for a CheckTx execution response only.
     Sync = 2,
     /// BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client returns immediately.
@@ -28,6 +29,7 @@ pub enum BroadcastMode {
 impl AsRef<str> for BroadcastMode {
     fn as_ref(&self) -> &str {
         match self {
+            BroadcastMode::Block => "BROADCAST_MODE_BLOCK",
             BroadcastMode::Sync => "BROADCAST_MODE_SYNC",
             BroadcastMode::Async => "BROADCAST_MODE_ASYNC",
         }
@@ -39,6 +41,7 @@ impl TryFrom<i32> for BroadcastMode {
 
     fn try_from(v: i32) -> Result<Self, Self::Error> {
         match v {
+            x if x == BroadcastMode::Block as i32 => Ok(BroadcastMode::Block),
             x if x == BroadcastMode::Sync as i32 => Ok(BroadcastMode::Sync),
             x if x == BroadcastMode::Async as i32 => Ok(BroadcastMode::Async),
             _ => Err(TxError::BroadcastMode { i: v }),
@@ -49,6 +52,7 @@ impl TryFrom<i32> for BroadcastMode {
 impl From<BroadcastMode> for ProtoBroadcastMode {
     fn from(mode: BroadcastMode) -> Self {
         match mode {
+            BroadcastMode::Block => ProtoBroadcastMode::Block,
             BroadcastMode::Sync => ProtoBroadcastMode::Sync,
             BroadcastMode::Async => ProtoBroadcastMode::Async,
         }
@@ -60,10 +64,10 @@ impl TryFrom<ProtoBroadcastMode> for BroadcastMode {
 
     fn try_from(mode: ProtoBroadcastMode) -> Result<Self, Self::Error> {
         match mode {
+            ProtoBroadcastMode::Block => Ok(BroadcastMode::Block),
             ProtoBroadcastMode::Sync => Ok(BroadcastMode::Sync),
             ProtoBroadcastMode::Async => Ok(BroadcastMode::Async),
             ProtoBroadcastMode::Unspecified => Err(TxError::BroadcastMode { i: 0 }),
-            ProtoBroadcastMode::Block => Err(TxError::BroadcastMode { i: 1 }),
         }
     }
 }


### PR DESCRIPTION
Alright, so unfortunately these changes are very broad and sweeping. Not really best practice but it's what I've got. There's tons of good stuff in here but it still requires lots of work and I've taken quite a few shortcuts. Mostly submitting this draft so @de-husk can have a look and submit some feedback. Quick summary of the changes:

- Update api to get rid of `CosmTome` struct and operate directly on the clients.
- Remove derivation path from `Key`
- Update Deps
- Change trait definition to be more modular
- Removed some local types in favour of using upstream types

@de-husk some specific questions for you.

- Can we get rid of the gRPC client? It would make our lives much easier now with the diverging api from CometBft
- Perhaps we should consider removing support for tx_commit, tx_sync, and just providing and automated Tx search when using async? This is the recommended way to submit txs, and if we create an automated way to perform the search afterwards then I don't see the benefit in supporting the deprecated tx_commit. The benefit here is mostly just getting rid of boilerplate, so maybe not worth it.